### PR TITLE
fix(Logbert): Optimize time offset settings and loading logic

### DIFF
--- a/src/Logbert/Dialogs/Docking/FrmLogDocument.cs
+++ b/src/Logbert/Dialogs/Docking/FrmLogDocument.cs
@@ -1028,9 +1028,9 @@ namespace Couchcoding.Logbert.Dialogs.Docking
             break;
         }
 
-        if (Settings.Default.TimeShiftValue != mTimeShiftValue.TotalMilliseconds)
+        if (Settings.Default.TimeShiftValue != newValue)
         {
-          Settings.Default.TimeShiftValue = mTimeShiftValue.TotalMilliseconds;
+          Settings.Default.TimeShiftValue = newValue;
           Settings.Default.SaveSettings();
         }
       }
@@ -1318,8 +1318,10 @@ namespace Couchcoding.Logbert.Dialogs.Docking
       ((FrmLogWindow)mLogWindow).OnLogMessageSelected += OnLogMessageSelected;
 
       LogDockPanel.Theme = ThemeManager.CurrentApplicationTheme.DockingTheme;
-
-      SetTimeshiftValue();
+      txtTimeShift.Text = ((int)Settings.Default.TimeShiftValue).ToString();
+      tsbTimeShift.Checked = true;
+      TsbTimeShiftClick(this, EventArgs.Empty);
+      // SetTimeshiftValue();
     }
 
     #endregion


### PR DESCRIPTION
- Revise the time offset setting logic to use newValue instead of mTimeShiftValue.TotalMilliseconds
- Update the time offset loading method to directly use Settings.Default.TimeShiftValue
- Remove the call to SetTimeshiftValue() method, opting to initialize the time offset when the form loads